### PR TITLE
In package.json:7, there are errors with filename.

### DIFF
--- a/Node/package.json
+++ b/Node/package.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "Abdul Khan"
   },
-  "main": "dist/cryptLib.js",
+  "main": "dist/CryptLib.js",
   "description": "CryptLib uses AES 256 for encryption or decryption. This library can be used for encryption and decryption of strings using Node on iOS, Android and Windows",
   "contributors": [
     {


### PR DESCRIPTION
It should be dist/**C**ryptLib.js not dist/**c**ryptLib.js, notice the C and c.

This problem cause fault on requiring the module.

[I notice this problem from this stackoverflow question](http://stackoverflow.com/questions/32565364/nodejs-module-not-found-error)
