### PR TITLE
C# Fix Error in "Ñ or ñ"

### DIFF
--- a/C-Sharp/CryptLib.cs
+++ b/C-Sharp/CryptLib.cs
@@ -22,7 +22,7 @@ namespace com.pakhee.common
 	 *****************************************************************/
 	public class CryptLib
 	{
-		UTF8Encoding _enc;
+		UTF8Encoding _enc = new UTF8Encoding(true, true);
 		RijndaelManaged _rcipher;
 		byte[] _key, _pwd, _ivBytes, _iv;
 		
@@ -117,13 +117,16 @@ namespace com.pakhee.common
 
 			if (_mode.Equals (EncryptMode.ENCRYPT)) {
 				//encrypt
-				byte[] plainText = _rcipher.CreateEncryptor().TransformFinalBlock(_enc.GetBytes(_inputText) , 0, _inputText.Length);
+
+                byte[] plainText = _rcipher.CreateEncryptor().TransformFinalBlock(_enc.GetBytes(_inputText), 0, _enc.GetBytes(_inputText).Length);
 				_out = Convert.ToBase64String(plainText);
+
 			}
 			if (_mode.Equals (EncryptMode.DECRYPT)) {
 				//decrypt
 				byte[] plainText = _rcipher.CreateDecryptor().TransformFinalBlock(Convert.FromBase64String(_inputText), 0, Convert.FromBase64String(_inputText).Length);
 				_out = _enc.GetString(plainText);
+
 			}
 			_rcipher.Dispose();
 			return _out;// return encrypted/decrypted string


### PR DESCRIPTION
I just found the bug in your c#. I have added UTF encoding to your
encryption.

This issue will be found if you encrypt a "Ñ or ñ" characters and
decrypt it. The return decrypted letter will be cut.

Example: {"lname": "ybañez"}  ,then encrypt and decrypt it.
Output will:  {"lname": "ybañe

This will make an error in deserializing JSON.